### PR TITLE
Re-added MGH (with website)

### DIFF
--- a/institutions_places_enriched.csv
+++ b/institutions_places_enriched.csv
@@ -241,6 +241,7 @@ Houghton Library,,42.373169,-71.115915,Cambridge,4931972,42.3751,-71.10561,Unite
 Gladys Krieble Delmas Foundation,,40.751219,-73.979982,New York City,5128581,40.71427,-74.00597,United States,city,delmas.org
 Ramapo College of New Jersey,,41.081503,-74.174627,Mahwah,5100776,41.08871,-74.14376,United States,city,www.ramapo.edu
 Facultad de Filosofía y Letras Universidad Nacional Autónoma de México (UNAM),,19.333993,-99.186841,Mexico City,3530597,19.42847,-99.12766,Mexico,city,www.filos.unam.mx
+Monumenta Germaniae Historica,http://d-nb.info/gnd/2043215-X,48.148141,11.580466,München,6559171,48.13452,11.571,Germany,city,http://www.mgh.de
 N/A,,,,,,,,,,
 Various,,,,,,,,,,
 not provided,,,,,,,,,,


### PR DESCRIPTION
Re-added the entry for the Monumenta Germaniae Historica, which
was lost with commit 50e3735a4f7c70df73fb2dfe2d3896fdf8c9d172.