### PR TITLE
Fixed typo in Archives Nationales coordinates

### DIFF
--- a/institutions_places_enriched.csv
+++ b/institutions_places_enriched.csv
@@ -40,7 +40,7 @@
 "Svenska Litteratursällskapet","http://d-nb.info/gnd/1005799-7",60.170814,24.955789,"Kruununhaka",650744,60.17174,24.9566,"Finland","city","http://www.sls.fi"
 "Institut Universitaire de France","http://d-nb.info/gnd/2160908-1",48.847431,2.34872,"Paris",2988507,48.85341,2.3488,"France","city","http://www.iufrance.fr"
 "Lafayette University Library",,45.77395,3.087964,"Clermont-Ferrand",3024635,45.77966,3.08628,"France","city","http://bibliotheque.clermont-universite.fr/bibliotheque-lafayette"
-"Archives Nationales",,498.948111,2.3644,"Pierrefitte-sur-Seine",2987271,48.96691,2.36104,"France","city","http://www.archives-nationales.culture.gouv.fr/"
+"Archives Nationales",,48.948111,2.3644,"Pierrefitte-sur-Seine",2987271,48.96691,2.36104,"France","city","http://www.archives-nationales.culture.gouv.fr/"
 "Université Bordeaux Montaigne","http://d-nb.info/gnd/1081101628",44.795414,-0.616322,"Bordeaux",3031582,44.84044,-0.5805,"France","city","http://www.u-bordeaux-montaigne.fr/en/index.html"
 "Université Paris-Sorbonne","http://d-nb.info/gnd/1210825449",48.848574,2.343257,"Paris",2988507,48.85341,2.3488,"France","city","https://www.sorbonne-universite.fr/universite"
 "Université Sorbonne Nouvelle Paris 3","http://d-nb.info/gnd/1020917-7",48.839804,2.353901,"Paris",2988507,48.85341,2.3488,"France","city","http://www.univ-paris3.fr"


### PR DESCRIPTION
I noticed this when working with the data, this should fix it.